### PR TITLE
fix to bookdown top page icon links

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -10,10 +10,10 @@ bookdown::gitbook:
         <li><a href="https://github.com/si2-urssi/plan" target="blank">Published from GitHub</a> via bookdown</li>
     download: [pdf]
     edit:
-      link: https://github.com/ropensci/dev_guide/edit/dev/%s
+      link: https://github.com/si2-urssi/plan/%s
       text: "Edit this chapter"
     history:
-      link: https://github.com/ropensci/dev_guide/commits/master/%s
+      link: https://github.com/si2-urssi/plan/commits/master/%s
       text: "Chapter edit history"
 bookdown::pdf_book:
   includes:


### PR DESCRIPTION
@karthik - can you check this before merging it - I think this will fix the errors that I currently see where these links go to the wrong place